### PR TITLE
Fix reduce when initialValue is falsy

### DIFF
--- a/lib/static-methods.js
+++ b/lib/static-methods.js
@@ -1,7 +1,7 @@
 /**
  * Implements ES5 [`Array#forEach()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) method.<br><br>
  * Executes the provided callback once for each element.<br>
- * Callbacks are run concurrently, 
+ * Callbacks are run concurrently,
  * and are only invoked for properties of the array that have been initialized (including those initialized with *undefined*), for unassigned ones `callback` is not run.<br>
  * @param {Array} array - Array to iterate over.
  * @param {Function} callback - Function to apply each item in `array`. Accepts three arguments: `currentValue`, `index` and `array`.
@@ -292,7 +292,7 @@ exports.filter = (array, callback, thisArg) => {
    * while keeping the order of the elements
    * (if you find a better way to do it please send a PR!)
    */
-  return new Promise(async (resolve, reject) => {    
+  return new Promise(async (resolve, reject) => {
     const promiseArray = [];
     for (let i = 0; i < array.length; i++) {
       if (i in array) {
@@ -336,12 +336,12 @@ exports.filterSeries = async (array, callback, thisArg) => {
  * @return {Promise} - Returns a Promise with the resultant value from the reduction.
  */
 exports.reduce = async (array, callback, initialValue) => {
-  if (array.length === 0 && !initialValue) {
+  if (array.length === 0 && initialValue === undefined) {
     throw TypeError('Reduce of empty array with no initial value');
   }
   let i;
   let previousValue;
-  if (typeof initialValue !== 'undefined') {
+  if (initialValue !== undefined) {
     previousValue = initialValue;
     i = 0;
   } else {

--- a/lib/static-methods.js
+++ b/lib/static-methods.js
@@ -341,7 +341,7 @@ exports.reduce = async (array, callback, initialValue) => {
   }
   let i;
   let previousValue;
-  if (initialValue) {
+  if (typeof initialValue !== 'undefined') {
     previousValue = initialValue;
     i = 0;
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -537,6 +537,29 @@ test('reduce with initialValue', async (t) => {
   t.is(sum, 7);
 });
 
+test('reduce with falsy initialValue', async (t) => {
+  const sum = await reduce(['1', '2', '3'], async (accumulator, currentValue, index, array) => {
+    await delay();
+    t.is(array[index], currentValue);
+    return accumulator + Number(currentValue);
+  }, 0);
+  t.is(sum, 6);
+  
+  const string = await reduce([1, 2, 3], async (accumulator, currentValue, index, array) => {
+    await delay();
+    t.is(array[index], currentValue);
+    return accumulator + String(currentValue);
+  }, '');
+  t.is(string, '123');
+  
+  const somePositive = await reduce([-1, 2, 3], async (accumulator, currentValue, index, array) => {
+    await delay();
+    t.is(array[index], currentValue);
+    return accumulator ? accumulator : currentValue > 0;
+  }, false);
+  t.is(somePositive, true);
+});
+
 test('reduce, throw inside callback', async function (t) {
   const err = await t.throws(reduce([2, 1, 3], () => {
     throw new Error('test');


### PR DESCRIPTION
For values like `0`, `''` and `false`, the reduce function would ignore the given initial value.