### PR TITLE
Add browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,16 @@
   "engines": {
     "node": ">=8.0.0"
   },
+  "browserify": {
+    "transform": [
+      [
+        "babelify",
+        {
+          "presets": ["es2015", "es2016", "es2017"]
+        }
+      ]
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/toniov/p-iteration"


### PR DESCRIPTION
This PR adds Browserify compatibility. Without this transform definition p-iteration cannot be used in non-nodeJS projects that use Browserify.

I verified this working in my cordova app.